### PR TITLE
fix: filter auto runners in database query and enhance runner display…

### DIFF
--- a/services/backend/functions/background_checks/checkDisconnectedAutoRunners.go
+++ b/services/backend/functions/background_checks/checkDisconnectedAutoRunners.go
@@ -17,7 +17,7 @@ func checkDisconnectedAutoRunners(db *bun.DB) {
 
 	// get all executions that are not finished
 	var runners []models.Runners
-	err := db.NewSelect().Model(&runners).Where("last_heartbeat < NOW() - INTERVAL '5 minutes'").Scan(context)
+	err := db.NewSelect().Model(&runners).Where("last_heartbeat < NOW() - INTERVAL '5 minutes' and auto_runner = ?", true).Scan(context)
 	if err != nil {
 		log.Error("Bot: Error getting running runners. ", err)
 	}

--- a/services/frontend/components/runners/list.tsx
+++ b/services/frontend/components/runners/list.tsx
@@ -6,6 +6,7 @@ import {
   Button,
   Card,
   CardBody,
+  Chip,
   Divider,
   Dropdown,
   DropdownItem,
@@ -252,9 +253,21 @@ export default function RunnersList({
                     <CardBody className="p-5">
                       <div className="flex justify-between items-start">
                         <div>
-                          <h3 className="text-lg font-semibold">
-                            {runner.name}
-                          </h3>
+                          <div className="flex items-center gap-2">
+                            <h3 className="text-lg font-semibold">
+                              {runner.name}
+                            </h3>
+                            {!runner.auto_runner && (
+                              <Chip
+                                color="primary"
+                                radius="sm"
+                                size="sm"
+                                variant="flat"
+                              >
+                                Persistent
+                              </Chip>
+                            )}
+                          </div>
                           <p className="text-small text-default-500 mt-1">
                             ID: {runner.id}
                           </p>


### PR DESCRIPTION
This pull request introduces changes to enhance the functionality of runner management in both the backend and frontend. The backend now filters auto-runners more precisely, while the frontend visually distinguishes persistent runners with a new UI element.

### Backend Improvements:
* **Filtering Auto-Runners in Disconnected Check**: Updated the `checkDisconnectedAutoRunners` function to include an additional filter (`auto_runner = true`) when querying runners with outdated heartbeats. This ensures only auto-runners are processed. (`services/backend/functions/background_checks/checkDisconnectedAutoRunners.go`, [services/backend/functions/background_checks/checkDisconnectedAutoRunners.goL20-R20](diffhunk://#diff-33f7c7a814583a2a1f00fd3f875d235b16fe605df05c606a6efe25f54a0b6611L20-R20))

### Frontend Enhancements:
* **Added `Chip` Component**: Imported the `Chip` component for use in the runners list UI. (`services/frontend/components/runners/list.tsx`, [services/frontend/components/runners/list.tsxR9](diffhunk://#diff-82dbce2bf034979f0237edf456d17a8e147cf0599e94c094d500b9fb7c5bf429R9))
* **Displayed Persistent Runner Badge**: Modified the `RunnersList` component to display a "Persistent" badge (using the `Chip` component) next to the name of runners that are not auto-runners. This visually distinguishes persistent runners from auto-runners. (`services/frontend/components/runners/list.tsx`, [services/frontend/components/runners/list.tsxR256-R270](diffhunk://#diff-82dbce2bf034979f0237edf456d17a8e147cf0599e94c094d500b9fb7c5bf429R256-R270))