### PR TITLE
Feature #142: implement option to rotate shared and project auto join tokens

### DIFF
--- a/services/backend/handlers/admins/rotate-auto-join-token.go
+++ b/services/backend/handlers/admins/rotate-auto-join-token.go
@@ -1,0 +1,31 @@
+package admins
+
+import (
+	"net/http"
+
+	"github.com/v1Flows/exFlow/services/backend/functions/httperror"
+	functions_runner "github.com/v1Flows/exFlow/services/backend/functions/runner"
+	"github.com/v1Flows/exFlow/services/backend/pkg/models"
+
+	"github.com/gin-gonic/gin"
+	_ "github.com/lib/pq"
+	"github.com/uptrace/bun"
+)
+
+func RotateAutoJoinToken(context *gin.Context, db *bun.DB) {
+	var settings models.Settings
+	var err error
+	settings.SharedRunnerAutoJoinToken, err = functions_runner.GenerateExFlowAutoJoinToken(db)
+	if err != nil {
+		httperror.InternalServerError(context, "Error rotating shared runner token", err)
+		return
+	}
+
+	_, err = db.NewUpdate().Model(&settings).Column("shared_runner_auto_join_token").Where("id = 1").Exec(context)
+	if err != nil {
+		httperror.InternalServerError(context, "Error rotating shared runner token", err)
+		return
+	}
+
+	context.JSON(http.StatusCreated, gin.H{"result": "success"})
+}

--- a/services/backend/handlers/projects/rotate-auto-join-token.go
+++ b/services/backend/handlers/projects/rotate-auto-join-token.go
@@ -1,0 +1,56 @@
+package projects
+
+import (
+	"errors"
+	"net/http"
+
+	"github.com/v1Flows/exFlow/services/backend/functions/gatekeeper"
+	"github.com/v1Flows/exFlow/services/backend/functions/httperror"
+	functions_runner "github.com/v1Flows/exFlow/services/backend/functions/runner"
+	"github.com/v1Flows/exFlow/services/backend/pkg/models"
+
+	"github.com/gin-gonic/gin"
+	_ "github.com/lib/pq"
+	log "github.com/sirupsen/logrus"
+	"github.com/uptrace/bun"
+)
+
+func RotateAutoJoinToken(context *gin.Context, db *bun.DB) {
+	projectID := context.Param("projectID")
+
+	// check if user has access to project
+	access, err := gatekeeper.CheckUserProjectAccess(projectID, context, db)
+	if err != nil {
+		httperror.InternalServerError(context, "Error checking for project access", err)
+		return
+	}
+	if !access {
+		httperror.Unauthorized(context, "You do not have access to this project", errors.New("you do not have access to this project"))
+		return
+	}
+
+	var project models.Projects
+	var tokens models.Tokens
+
+	// delete all existing auto join tokens for the project
+	_, err = db.NewDelete().Model(&tokens).Where("project_id = ? and type = ?", projectID, "project_auto_runner").Exec(context)
+	if err != nil {
+		log.Error(err)
+		httperror.InternalServerError(context, "Error deleting existing auto join tokens", err)
+		return
+	}
+
+	project.RunnerAutoJoinToken, err = functions_runner.GenerateProjectAutoJoinToken(projectID, db)
+	if err != nil {
+		return
+	}
+
+	_, err = db.NewUpdate().Model(&project).Column("runner_auto_join_token").Where("id = ?", projectID).Exec(context)
+	if err != nil {
+		log.Error(err)
+		httperror.InternalServerError(context, "Error creating project on db", err)
+		return
+	}
+
+	context.JSON(http.StatusCreated, gin.H{"result": "success"})
+}

--- a/services/backend/router/admin.go
+++ b/services/backend/router/admin.go
@@ -70,6 +70,11 @@ func Admin(router *gin.RouterGroup, db *bun.DB) {
 			admins.DeleteToken(c, db)
 		})
 
+		// auto-join-token
+		admin.PUT("/auto-join-token/rotate", func(c *gin.Context) {
+			admins.RotateAutoJoinToken(c, db)
+		})
+
 		// projects
 		admin.PUT("/projects/:projectID/status", func(c *gin.Context) {
 			admins.ChangeProjectStatus(c, db)

--- a/services/backend/router/projects.go
+++ b/services/backend/router/projects.go
@@ -53,6 +53,11 @@ func Projects(router *gin.RouterGroup, db *bun.DB) {
 			projects.DeleteToken(c, db)
 		})
 
+		// auto-join-token
+		project.PUT("/:projectID/auto-join-token/rotate", func(c *gin.Context) {
+			projects.RotateAutoJoinToken(c, db)
+		})
+
 		// project members
 		project.POST("/:projectID/member", func(c *gin.Context) {
 			projects.AddProjectMember(c, db)

--- a/services/frontend/components/admin/runners/heading.tsx
+++ b/services/frontend/components/admin/runners/heading.tsx
@@ -5,9 +5,11 @@ import { Icon } from "@iconify/react";
 
 import CreateProjectModal from "@/components/modals/projects/create";
 import Reloader from "@/components/reloader/Reloader";
+import RotateSharedAutoJoinTokenModal from "@/components/modals/admin/rotateSharedAutoJoinToken";
 
 export default function AdminRunnersHeading({ settings }: any) {
   const newProjectModal = useDisclosure();
+  const rotateSharedAutoJoinTokenModal = useDisclosure();
 
   const copyToken = () => {
     navigator.clipboard.writeText(settings.shared_runner_auto_join_token);
@@ -35,6 +37,16 @@ export default function AdminRunnersHeading({ settings }: any) {
             >
               Copy Shared Runner Token
             </Button>
+            <Button
+              color="warning"
+              startContent={
+                <Icon icon="hugeicons:rotate-clockwise" width={18} />
+              }
+              variant="flat"
+              onPress={rotateSharedAutoJoinTokenModal.onOpen}
+            >
+              Rotate Shared Runner Token
+            </Button>
           </div>
 
           <div className="flex sm:hidden gap-2">
@@ -52,6 +64,9 @@ export default function AdminRunnersHeading({ settings }: any) {
         </div>
       </div>
       <CreateProjectModal disclosure={newProjectModal} />
+      <RotateSharedAutoJoinTokenModal
+        disclosure={rotateSharedAutoJoinTokenModal}
+      />
     </main>
   );
 }

--- a/services/frontend/components/modals/admin/rotateSharedAutoJoinToken.tsx
+++ b/services/frontend/components/modals/admin/rotateSharedAutoJoinToken.tsx
@@ -1,0 +1,131 @@
+"use client";
+
+import type { UseDisclosureReturn } from "@heroui/use-disclosure";
+
+import {
+  addToast,
+  Button,
+  Modal,
+  ModalBody,
+  ModalContent,
+  ModalFooter,
+  ModalHeader,
+} from "@heroui/react";
+import { useRouter } from "next/navigation";
+import React from "react";
+import { Icon } from "@iconify/react";
+
+import ErrorCard from "@/components/error/ErrorCard";
+import AdminRotateSharedAutoJoinToken from "@/lib/fetch/admin/PUT/RotateAutoJoinToken";
+
+export default function RotateSharedAutoJoinTokenModal({
+  disclosure,
+}: {
+  disclosure: UseDisclosureReturn;
+}) {
+  const router = useRouter();
+  const { isOpen, onOpenChange } = disclosure;
+
+  const [isLoading, setIsLoading] = React.useState(false);
+  const [error, setError] = React.useState(false);
+  const [errorText, setErrorText] = React.useState("");
+  const [errorMessage, setErrorMessage] = React.useState("");
+
+  async function handleRotateToken() {
+    setIsLoading(true);
+
+    const response = (await AdminRotateSharedAutoJoinToken()) as any;
+
+    if (!response) {
+      setIsLoading(false);
+      setError(true);
+      setErrorText("Failed to rotate token");
+      setErrorMessage("Failed to rotate token");
+      addToast({
+        title: "Token",
+        description: "Failed to rotate token",
+        color: "danger",
+        variant: "flat",
+      });
+
+      return;
+    }
+
+    if (response.success) {
+      setIsLoading(false);
+      setError(false);
+      setErrorText("");
+      setErrorMessage("");
+      onOpenChange();
+      addToast({
+        title: "Token",
+        description: "Token rotated successfully",
+        color: "success",
+        variant: "flat",
+      });
+      router.refresh();
+
+      return;
+    } else {
+      setError(true);
+      setErrorText(response.error);
+      setErrorMessage(response.message);
+      setIsLoading(false);
+      addToast({
+        title: "Token",
+        description: "Failed to rotate token",
+        color: "danger",
+        variant: "flat",
+      });
+    }
+  }
+
+  return (
+    <>
+      <Modal isOpen={isOpen} placement="center" onOpenChange={onOpenChange}>
+        <ModalContent>
+          {(onClose) => (
+            <>
+              <ModalHeader className="flex flex-wrap items-center">
+                <div className="flex flex-col gap-2">
+                  <p className="text-lg font-bold">Are you sure?</p>
+                  <p className="text-sm text-default-500">
+                    After rotating the auto-join token, all existing shared
+                    runners using this token will be unable to join. You will
+                    need to update the runners with the new token to allow them
+                    to join again.
+                  </p>
+                </div>
+              </ModalHeader>
+              {error && (
+                <ModalBody>
+                  <ErrorCard error={errorText} message={errorMessage} />
+                </ModalBody>
+              )}
+              <ModalFooter className="grid grid-cols-2">
+                <Button
+                  color="default"
+                  startContent={<Icon icon="hugeicons:cancel-01" width={18} />}
+                  variant="ghost"
+                  onPress={onClose}
+                >
+                  Cancel
+                </Button>
+                <Button
+                  color="warning"
+                  isLoading={isLoading}
+                  startContent={
+                    <Icon icon="hugeicons:rotate-clockwise" width={18} />
+                  }
+                  onPress={handleRotateToken}
+                >
+                  Rotate
+                </Button>
+              </ModalFooter>
+            </>
+          )}
+        </ModalContent>
+      </Modal>
+    </>
+  );
+}

--- a/services/frontend/components/modals/projects/rotateAutoJoinToken.tsx
+++ b/services/frontend/components/modals/projects/rotateAutoJoinToken.tsx
@@ -1,0 +1,131 @@
+"use client";
+
+import type { UseDisclosureReturn } from "@heroui/use-disclosure";
+
+import {
+  addToast,
+  Button,
+  Modal,
+  ModalBody,
+  ModalContent,
+  ModalFooter,
+  ModalHeader,
+} from "@heroui/react";
+import { useRouter } from "next/navigation";
+import React from "react";
+import { Icon } from "@iconify/react";
+
+import ErrorCard from "@/components/error/ErrorCard";
+import RotateAutoJoinToken from "@/lib/fetch/project/PUT/RotateAutoJoinToken";
+
+export default function RotateAutoJoinTokenModal({
+  disclosure,
+  projectID,
+}: {
+  disclosure: UseDisclosureReturn;
+  projectID: any;
+}) {
+  const router = useRouter();
+  const { isOpen, onOpenChange } = disclosure;
+
+  const [isLoading, setIsLoading] = React.useState(false);
+  const [error, setError] = React.useState(false);
+  const [errorText, setErrorText] = React.useState("");
+  const [errorMessage, setErrorMessage] = React.useState("");
+
+  async function handleRotateToken() {
+    setIsLoading(true);
+
+    const response = (await RotateAutoJoinToken(projectID)) as any;
+
+    if (!response) {
+      setIsLoading(false);
+      setError(true);
+      setErrorText("Failed to rotate token");
+      setErrorMessage("Failed to rotate token");
+      addToast({
+        title: "Token",
+        description: "Failed to rotate token",
+        color: "danger",
+        variant: "flat",
+      });
+
+      return;
+    }
+
+    if (response.success) {
+      setIsLoading(false);
+      setError(false);
+      setErrorText("");
+      setErrorMessage("");
+      router.refresh();
+      onOpenChange();
+      addToast({
+        title: "Token",
+        description: "Token rotated successfully",
+        color: "success",
+        variant: "flat",
+      });
+    } else {
+      setError(true);
+      setErrorText(response.error);
+      setErrorMessage(response.message);
+      setIsLoading(false);
+      addToast({
+        title: "Token",
+        description: "Failed to rotate token",
+        color: "danger",
+        variant: "flat",
+      });
+    }
+  }
+
+  return (
+    <>
+      <Modal isOpen={isOpen} placement="center" onOpenChange={onOpenChange}>
+        <ModalContent>
+          {(onClose) => (
+            <>
+              <ModalHeader className="flex flex-wrap items-center">
+                <div className="flex flex-col gap-2">
+                  <p className="text-lg font-bold">Are you sure?</p>
+                  <p className="text-sm text-default-500">
+                    After rotating the auto-join token, all existing runners
+                    using this token will be unable to join the project. You
+                    will need to update the runners with the new token to allow
+                    them to join again.
+                  </p>
+                </div>
+              </ModalHeader>
+              {error && (
+                <ModalBody>
+                  <ErrorCard error={errorText} message={errorMessage} />
+                </ModalBody>
+              )}
+              <ModalFooter className="grid grid-cols-2">
+                <Button
+                  color="default"
+                  startContent={<Icon icon="hugeicons:cancel-01" width={18} />}
+                  variant="ghost"
+                  onPress={onClose}
+                >
+                  Cancel
+                </Button>
+                <Button
+                  color="warning"
+                  isLoading={isLoading}
+                  startContent={
+                    <Icon icon="hugeicons:rotate-clockwise" width={18} />
+                  }
+                  onPress={handleRotateToken}
+                >
+                  Rotate
+                </Button>
+              </ModalFooter>
+            </>
+          )}
+        </ModalContent>
+      </Modal>
+    </>
+  );
+}

--- a/services/frontend/components/projects/project/RunnerDetails.tsx
+++ b/services/frontend/components/projects/project/RunnerDetails.tsx
@@ -15,6 +15,7 @@ import { Icon } from "@iconify/react";
 import CreateRunnerModal from "@/components/modals/runner/create";
 import UpdateProject from "@/lib/fetch/project/PUT/UpdateProject";
 import canEditProject from "@/lib/functions/canEditProject";
+import RotateAutoJoinTokenModal from "@/components/modals/projects/rotateAutoJoinToken";
 
 export default function ProjectRunnerDetails({
   project,
@@ -28,6 +29,7 @@ export default function ProjectRunnerDetails({
   const router = useRouter();
 
   const addRunnerModal = useDisclosure();
+  const rotateAutoJoinTokenModal = useDisclosure();
 
   const [sharedRunners, setSharedRunners] = useState(project.shared_runners);
   const [autoJoin, setAutoJoin] = useState(project.enable_auto_runners);
@@ -187,16 +189,30 @@ export default function ProjectRunnerDetails({
               </p>
             </div>
             <Spacer y={2} />
-            <Button
-              color="primary"
-              isDisabled={project.disabled && user.role !== "admin"}
-              size="sm"
-              variant="flat"
-              onPress={copyJoinToken}
-            >
-              <Icon icon="hugeicons:copy-02" width={18} />
-              Copy Token
-            </Button>
+            <div className="flex items-center gap-2">
+              <Button
+                color="primary"
+                isDisabled={project.disabled && user.role !== "admin"}
+                size="sm"
+                variant="flat"
+                onPress={copyJoinToken}
+              >
+                <Icon icon="hugeicons:copy-02" width={18} />
+                Copy Token
+              </Button>
+              <Tooltip content="Rotate Token">
+                <Button
+                  isIconOnly
+                  color="warning"
+                  isDisabled={project.disabled && user.role !== "admin"}
+                  size="sm"
+                  variant="flat"
+                  onPress={rotateAutoJoinTokenModal.onOpen}
+                >
+                  <Icon icon="hugeicons:rotate-clockwise" width={18} />
+                </Button>
+              </Tooltip>
+            </div>
           </CardBody>
         </Card>
 
@@ -231,6 +247,10 @@ export default function ProjectRunnerDetails({
         disclosure={addRunnerModal}
         project={project}
         shared_runner={false}
+      />
+      <RotateAutoJoinTokenModal
+        disclosure={rotateAutoJoinTokenModal}
+        projectID={project.id}
       />
     </>
   );

--- a/services/frontend/lib/fetch/admin/PUT/RotateAutoJoinToken.ts
+++ b/services/frontend/lib/fetch/admin/PUT/RotateAutoJoinToken.ts
@@ -1,0 +1,70 @@
+"use server";
+
+import { cookies } from "next/headers";
+
+type Result = {
+  result: string;
+};
+
+type ErrorResponse = {
+  success: false;
+  error: string;
+  message: string;
+};
+
+type SuccessResponse = {
+  success: true;
+  data: Result;
+};
+
+export default async function AdminRotateSharedAutoJoinToken(): Promise<
+  SuccessResponse | ErrorResponse
+> {
+  try {
+    const cookieStore = await cookies();
+    const token = cookieStore.get("session");
+
+    if (!token) {
+      return {
+        success: false,
+        error: "Authentication token not found",
+        message: "User is not authenticated",
+      };
+    }
+
+    const res = await fetch(
+      `${process.env.NEXT_PUBLIC_API_URL}/api/v1/admin/auto-join-token/rotate`,
+      {
+        method: "PUT",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: token.value,
+        },
+        body: JSON.stringify({}),
+      },
+    );
+
+    if (!res.ok) {
+      const errorData = await res.json();
+
+      return {
+        success: false,
+        error: `API error: ${res.status} ${res.statusText}`,
+        message: errorData.message || "An error occurred",
+      };
+    }
+
+    const data = await res.json();
+
+    return {
+      success: true,
+      data,
+    };
+  } catch (error) {
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : "Unknown error occurred",
+      message: "Failed to rotate shared auto join token",
+    };
+  }
+}

--- a/services/frontend/lib/fetch/project/PUT/RotateAutoJoinToken.ts
+++ b/services/frontend/lib/fetch/project/PUT/RotateAutoJoinToken.ts
@@ -1,0 +1,70 @@
+"use server";
+
+import { cookies } from "next/headers";
+
+type Result = {
+  result: string;
+};
+
+type ErrorResponse = {
+  success: false;
+  error: string;
+  message: string;
+};
+
+type SuccessResponse = {
+  success: true;
+  data: Result;
+};
+
+export default async function RotateAutoJoinToken(
+  id: string,
+): Promise<SuccessResponse | ErrorResponse> {
+  try {
+    const cookieStore = await cookies();
+    const token = cookieStore.get("session");
+
+    if (!token) {
+      return {
+        success: false,
+        error: "Authentication token not found",
+        message: "User is not authenticated",
+      };
+    }
+
+    const res = await fetch(
+      `${process.env.NEXT_PUBLIC_API_URL}/api/v1/projects/${id}/auto-join-token/rotate`,
+      {
+        method: "PUT",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: token.value,
+        },
+        body: JSON.stringify({}),
+      },
+    );
+
+    if (!res.ok) {
+      const errorData = await res.json();
+
+      return {
+        success: false,
+        error: `API error: ${res.status} ${res.statusText}`,
+        message: errorData.message || "An error occurred",
+      };
+    }
+
+    const data = await res.json();
+
+    return {
+      success: true,
+      data,
+    };
+  } catch (error) {
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : "Unknown error occurred",
+      message: "Failed to rotate auto join token",
+    };
+  }
+}


### PR DESCRIPTION
This pull request introduces functionality to rotate auto-join tokens for both shared runners and project-specific runners. It includes backend API endpoints, frontend modals for user interaction, and associated utility functions. These changes enhance security by allowing users to regenerate tokens when needed.

### Backend Changes

* **Shared Runner Token Rotation**: Added a new handler `RotateAutoJoinToken` in `services/backend/handlers/admins/rotate-auto-join-token.go` to rotate the shared runner token and update the database.
* **Project Runner Token Rotation**: Added a new handler `RotateAutoJoinToken` in `services/backend/handlers/projects/rotate-auto-join-token.go` to handle token rotation for project-specific runners, including access checks and token cleanup.
* **Routing Updates**:
  - Added a route in `services/backend/router/admin.go` to expose the shared runner token rotation endpoint.
  - Added a route in `services/backend/router/projects.go` to expose the project runner token rotation endpoint.

### Frontend Changes

* **Shared Runner Token Modal**: Implemented `RotateSharedAutoJoinTokenModal` in `services/frontend/components/modals/admin/rotateSharedAutoJoinToken.tsx` for rotating shared runner tokens, with error handling and user feedback.
* **Project Runner Token Modal**: Added `RotateAutoJoinTokenModal` in `services/frontend/components/modals/projects/rotateAutoJoinToken.tsx` for project-specific token rotation, including a confirmation dialog and error handling.
* **UI Integration**:
  - Updated `AdminRunnersHeading` to include a button for rotating shared runner tokens. [[1]](diffhunk://#diff-88a354a7e6dc420f1c23eb3a2f07ec6e1f54c1913912721e1dc26c7817bf4278R40-R49) [[2]](diffhunk://#diff-88a354a7e6dc420f1c23eb3a2f07ec6e1f54c1913912721e1dc26c7817bf4278R67-R69)
  - Updated `ProjectRunnerDetails` to include a button and tooltip for rotating project-specific tokens. [[1]](diffhunk://#diff-78500cfa90b8b9f16a8cefbf1ddd66746bbfc2ce1e30174c226798713eeab71bR203-R215) [[2]](diffhunk://#diff-78500cfa90b8b9f16a8cefbf1ddd66746bbfc2ce1e30174c226798713eeab71bR251-R254)

### Utility Functions

* **API Utilities**:
  - Added `AdminRotateSharedAutoJoinToken` in `services/frontend/lib/fetch/admin/PUT/RotateAutoJoinToken.ts` to handle API requests for shared runner token rotation.
  - Added `RotateAutoJoinToken` in `services/frontend/lib/fetch/project/PUT/RotateAutoJoinToken.ts` to handle API requests for project-specific token rotation.