### PR TITLE
Feature #170: implement plugin params depends_on

### DIFF
--- a/services/backend/go.mod
+++ b/services/backend/go.mod
@@ -73,6 +73,6 @@ require (
 	github.com/sirupsen/logrus v1.9.3
 	github.com/spf13/viper v1.20.1
 	github.com/uptrace/bun/dialect/pgdialect v1.2.11
-	github.com/v1Flows/shared-library v1.0.21
+	github.com/v1Flows/shared-library v1.0.23
 	golang.org/x/sys v0.33.0 // indirect
 )

--- a/services/backend/go.sum
+++ b/services/backend/go.sum
@@ -131,8 +131,8 @@ github.com/uptrace/bun/extra/bunotel v1.2.11 h1:ddt96XrbvlVZu5vBddP6WmbD6bdeJTaW
 github.com/uptrace/bun/extra/bunotel v1.2.11/go.mod h1:w6Mhie5tLFeP+5ryjq4PvgZEESRJ1iL2cbvxhm+f8q4=
 github.com/uptrace/opentelemetry-go-extra/otelsql v0.3.2 h1:ZjUj9BLYf9PEqBn8W/OapxhPjVRdC6CsXTdULHsyk5c=
 github.com/uptrace/opentelemetry-go-extra/otelsql v0.3.2/go.mod h1:O8bHQfyinKwTXKkiKNGmLQS7vRsqRxIQTFZpYpHK3IQ=
-github.com/v1Flows/shared-library v1.0.21 h1:G7GFplYrvmTRzJBvzSlqFEli54a+QlhORPdZ4pAC3ps=
-github.com/v1Flows/shared-library v1.0.21/go.mod h1:UVP6m6Nri6JC3L0xS3wkbqGvfQJ5fsYIJx81Gfj1TFw=
+github.com/v1Flows/shared-library v1.0.23 h1:xczFEU4SOGVeg1hCFof5A3FjKnPv5kXmf746EWPS4EA=
+github.com/v1Flows/shared-library v1.0.23/go.mod h1:UVP6m6Nri6JC3L0xS3wkbqGvfQJ5fsYIJx81Gfj1TFw=
 github.com/vmihailenco/msgpack/v5 v5.4.1 h1:cQriyiUvjTwOHg8QZaPihLWeRAAVoCpE00IUPn0Bjt8=
 github.com/vmihailenco/msgpack/v5 v5.4.1/go.mod h1:GaZTsDaehaPpQVyxrf5mtQlH+pc21PIudVV/E3rRQok=
 github.com/vmihailenco/tagparser/v2 v2.0.0 h1:y09buUbR+b5aycVFQs/g70pqKVZNBmxwAhO7/IwNM9g=

--- a/services/frontend/components/modals/actions/add.tsx
+++ b/services/frontend/components/modals/actions/add.tsx
@@ -663,6 +663,22 @@ export default function AddActionModal({
                                 </p>
                                 <div className="grid lg:grid-cols-2 gap-2">
                                   {action.params.map((param: any) => {
+                                    // an param can have depends_on set. If it is check, check for the required param and if its value matches
+                                    if (param.depends_on.key !== "") {
+                                      const dependsOnParam = action.params.find(
+                                        (p: any) =>
+                                          p.key === param.depends_on.key,
+                                      );
+
+                                      if (
+                                        !dependsOnParam ||
+                                        dependsOnParam.value !==
+                                          param.depends_on.value
+                                      ) {
+                                        return null; // skip this param if the condition is not met
+                                      }
+                                    }
+
                                     return (param.category ||
                                       "Uncategorized") === category ? (
                                       param.type === "text" ||

--- a/services/frontend/components/modals/actions/copy.tsx
+++ b/services/frontend/components/modals/actions/copy.tsx
@@ -381,6 +381,22 @@ export default function CopyActionModal({
                               </p>
                               <div className="grid lg:grid-cols-2 gap-2">
                                 {action.params.map((param: any) => {
+                                  // an param can have depends_on set. If it is check, check for the required param and if its value matches
+                                  if (param.depends_on.key !== "") {
+                                    const dependsOnParam = action.params.find(
+                                      (p: any) =>
+                                        p.key === param.depends_on.key,
+                                    );
+
+                                    if (
+                                      !dependsOnParam ||
+                                      dependsOnParam.value !==
+                                        param.depends_on.value
+                                    ) {
+                                      return null; // skip this param if the condition is not met
+                                    }
+                                  }
+
                                   return (param.category || "Uncategorized") ===
                                     category ? (
                                     param.type === "text" ||

--- a/services/frontend/components/modals/actions/edit.tsx
+++ b/services/frontend/components/modals/actions/edit.tsx
@@ -368,6 +368,22 @@ export default function EditActionModal({
                               </p>
                               <div className="grid lg:grid-cols-2 gap-2">
                                 {action.params.map((param: any) => {
+                                  // an param can have depends_on set. If it is check, check for the required param and if its value matches
+                                  if (param.depends_on.key !== "") {
+                                    const dependsOnParam = action.params.find(
+                                      (p: any) =>
+                                        p.key === param.depends_on.key,
+                                    );
+
+                                    if (
+                                      !dependsOnParam ||
+                                      dependsOnParam.value !==
+                                        param.depends_on.value
+                                    ) {
+                                      return null; // skip this param if the condition is not met
+                                    }
+                                  }
+
                                   return (param.category || "Uncategorized") ===
                                     category ? (
                                     param.type === "text" ||

--- a/services/frontend/components/modals/actions/transferCopy.tsx
+++ b/services/frontend/components/modals/actions/transferCopy.tsx
@@ -558,6 +558,22 @@ export default function CopyActionToDifferentFlowModal({
                                 </p>
                                 <div className="grid lg:grid-cols-2 gap-2">
                                   {action.params.map((param: any) => {
+                                    // an param can have depends_on set. If it is check, check for the required param and if its value matches
+                                    if (param.depends_on.key !== "") {
+                                      const dependsOnParam = action.params.find(
+                                        (p: any) =>
+                                          p.key === param.depends_on.key,
+                                      );
+
+                                      if (
+                                        !dependsOnParam ||
+                                        dependsOnParam.value !==
+                                          param.depends_on.value
+                                      ) {
+                                        return null; // skip this param if the condition is not met
+                                      }
+                                    }
+
                                     return (param.category ||
                                       "Uncategorized") === category ? (
                                       param.type === "text" ||

--- a/services/frontend/components/modals/actions/upgrade.tsx
+++ b/services/frontend/components/modals/actions/upgrade.tsx
@@ -399,6 +399,23 @@ export default function UpgradeActionModal({
                                   <div className="grid lg:grid-cols-2 gap-2">
                                     {actionOldVersion.params.map(
                                       (param: any) => {
+                                        // an param can have depends_on set. If it is check, check for the required param and if its value matches
+                                        if (param.depends_on.key !== "") {
+                                          const dependsOnParam =
+                                            actionOldVersion.params.find(
+                                              (p: any) =>
+                                                p.key === param.depends_on.key,
+                                            );
+
+                                          if (
+                                            !dependsOnParam ||
+                                            dependsOnParam.value !==
+                                              param.depends_on.value
+                                          ) {
+                                            return null; // skip this param if the condition is not met
+                                          }
+                                        }
+
                                         return (param.category ||
                                           "Uncategorized") === category ? (
                                           param.type === "text" ||
@@ -648,6 +665,23 @@ export default function UpgradeActionModal({
                                   <div className="grid lg:grid-cols-2 gap-2">
                                     {actionNewVersion.params.map(
                                       (param: any) => {
+                                        // an param can have depends_on set. If it is check, check for the required param and if its value matches
+                                        if (param.depends_on.key !== "") {
+                                          const dependsOnParam =
+                                            actionNewVersion.params.find(
+                                              (p: any) =>
+                                                p.key === param.depends_on.key,
+                                            );
+
+                                          if (
+                                            !dependsOnParam ||
+                                            dependsOnParam.value !==
+                                              param.depends_on.value
+                                          ) {
+                                            return null; // skip this param if the condition is not met
+                                          }
+                                        }
+
                                         return (param.category ||
                                           "Uncategorized") === category ? (
                                           param.type === "text" ||


### PR DESCRIPTION
This pull request introduces two main updates: a version bump for a shared library in the backend and the addition of conditional rendering logic for parameters in several frontend modals. Below is a detailed breakdown of the changes:

### Backend Update:
* **Dependency Update**: Updated the `github.com/v1Flows/shared-library` dependency from version `v1.0.21` to `v1.0.23` in `services/backend/go.mod`. This likely includes bug fixes or feature enhancements from the shared library.

### Frontend Enhancements:
* **Conditional Parameter Rendering**: Added logic to conditionally render parameters in multiple modals based on a `depends_on` field. If a parameter has a `depends_on` condition, it will only be displayed if the specified dependency's key and value match. This change ensures dynamic control over parameter visibility in the following modals:
  - `AddActionModal` (`services/frontend/components/modals/actions/add.tsx`)
  - `CopyActionModal` (`services/frontend/components/modals/actions/copy.tsx`)
  - `EditActionModal` (`services/frontend/components/modals/actions/edit.tsx`)
  - `CopyActionToDifferentFlowModal` (`services/frontend/components/modals/actions/transferCopy.tsx`)
  - `UpgradeActionModal` for both old and new versions of actions (`services/frontend/components/modals/actions/upgrade.tsx`) [[1]](diffhunk://#diff-33297de4734c45a2d52c75ddaf915c0418decbcf7a33bf70b10359bacd82db06R402-R418) [[2]](diffhunk://#diff-33297de4734c45a2d52c75ddaf915c0418decbcf7a33bf70b10359bacd82db06R668-R684)