### PR TITLE
feat: conditionally render admin actions based on mobile view

### DIFF
--- a/services/frontend/components/executions/execution/executionStepsAccordion.tsx
+++ b/services/frontend/components/executions/execution/executionStepsAccordion.tsx
@@ -265,11 +265,13 @@ export function ExecutionStepsAccordion({
                       <span>{getDuration(step)}</span>
                     </div>
 
-                    <div className="flex items-center gap-1">
-                      {userDetails.role === "admin" && (
-                        <AdminStepActions execution={execution} step={step} />
-                      )}
-                    </div>
+                    {!isMobile && (
+                      <div className="flex items-center gap-1">
+                        {userDetails.role === "admin" && (
+                          <AdminStepActions execution={execution} step={step} />
+                        )}
+                      </div>
+                    )}
                   </div>
                 }
               >


### PR DESCRIPTION
This pull request includes a small change to the `ExecutionStepsAccordion` component in the `executionStepsAccordion.tsx` file. The change conditionally renders the admin step actions only when the user is not on a mobile device.