### PR TITLE
feat: add line numbering and improved styling for message display in execution steps

### DIFF
--- a/services/frontend/components/executions/execution/executionStepsAccordion.tsx
+++ b/services/frontend/components/executions/execution/executionStepsAccordion.tsx
@@ -367,28 +367,51 @@ export function ExecutionStepsAccordion({
                               className="w-full"
                               radius="sm"
                             >
-                              {step.messages.flatMap(
-                                (data: any, dataIndex: number) =>
-                                  data.lines?.map(
-                                    (line: any, lineIndex: number) => (
-                                      <div
-                                        key={`${dataIndex}-${lineIndex}`}
-                                        className={`container flex-cols font-semibold flex items-center gap-2`}
-                                      >
-                                        <p className="text-default-500 text-opacity-70">
-                                          {new Date(
-                                            line.timestamp,
-                                          ).toLocaleString()}
-                                        </p>
-                                        <p
-                                          className={`text-${lineColor(line)}`}
-                                        >
-                                          {line.content}
-                                        </p>
-                                      </div>
-                                    ),
-                                  ) || [],
-                              )}
+                              {(() => {
+                                let globalLineNumber = 1;
+
+                                return step.messages.flatMap(
+                                  (data: any, dataIndex: number) =>
+                                    data.lines?.map(
+                                      (line: any, lineIndex: number) => {
+                                        const currentLineNumber =
+                                          globalLineNumber++;
+
+                                        return (
+                                          <div
+                                            key={`${dataIndex}-${lineIndex}`}
+                                            className={`container flex items-start gap-3 py-1 hover:bg-default-100/50 transition-colors`}
+                                          >
+                                            <div className="flex-shrink-0 w-8 text-right">
+                                              <span className="text-xs text-default-400 font-mono select-none">
+                                                {currentLineNumber}
+                                              </span>
+                                            </div>
+                                            <div className="flex-shrink-0">
+                                              <span className="text-xs text-default-500 text-opacity-70 font-mono">
+                                                {new Date(
+                                                  line.timestamp,
+                                                ).toLocaleTimeString([], {
+                                                  hour12: false,
+                                                  hour: "2-digit",
+                                                  minute: "2-digit",
+                                                  second: "2-digit",
+                                                })}
+                                              </span>
+                                            </div>
+                                            <div className="flex-1 min-w-0">
+                                              <span
+                                                className={`text-sm font-medium text-${lineColor(line)} break-words`}
+                                              >
+                                                {line.content}
+                                              </span>
+                                            </div>
+                                          </div>
+                                        );
+                                      },
+                                    ) || [],
+                                );
+                              })()}
                               <div
                                 ref={(el) => {
                                   messagesEndRef.current[step.id] = el;

--- a/services/frontend/components/executions/execution/executionStepsTable.tsx
+++ b/services/frontend/components/executions/execution/executionStepsTable.tsx
@@ -422,22 +422,50 @@ export function ExecutionStepsTable({
                         className="w-full"
                         radius="sm"
                       >
-                        {step.messages.flatMap(
-                          (data: any, dataIndex: number) =>
-                            data.lines?.map((line: any, lineIndex: number) => (
-                              <div
-                                key={`${dataIndex}-${lineIndex}`}
-                                className={`container flex-cols font-semibold flex items-center gap-2`}
-                              >
-                                <p className="text-default-500 text-opacity-70">
-                                  {new Date(line.timestamp).toLocaleString()}
-                                </p>
-                                <p className={`text-${lineColor(line)}`}>
-                                  {line.content}
-                                </p>
-                              </div>
-                            )) || [],
-                        )}
+                        {(() => {
+                          let globalLineNumber = 1;
+
+                          return step.messages.flatMap(
+                            (data: any, dataIndex: number) =>
+                              data.lines?.map(
+                                (line: any, lineIndex: number) => {
+                                  const currentLineNumber = globalLineNumber++;
+
+                                  return (
+                                    <div
+                                      key={`${dataIndex}-${lineIndex}`}
+                                      className={`container flex items-start gap-3 py-1 hover:bg-default-100/50 transition-colors`}
+                                    >
+                                      <div className="flex-shrink-0 w-8 text-right">
+                                        <span className="text-xs text-default-400 font-mono select-none">
+                                          {currentLineNumber}
+                                        </span>
+                                      </div>
+                                      <div className="flex-shrink-0">
+                                        <span className="text-xs text-default-500 text-opacity-70 font-mono">
+                                          {new Date(
+                                            line.timestamp,
+                                          ).toLocaleTimeString([], {
+                                            hour12: false,
+                                            hour: "2-digit",
+                                            minute: "2-digit",
+                                            second: "2-digit",
+                                          })}
+                                        </span>
+                                      </div>
+                                      <div className="min-w-0">
+                                        <span
+                                          className={`text-sm font-medium text-${lineColor(line)} break-words`}
+                                        >
+                                          {line.content}
+                                        </span>
+                                      </div>
+                                    </div>
+                                  );
+                                },
+                              ) || [],
+                          );
+                        })()}
                       </Snippet>
                     </div>
 


### PR DESCRIPTION
This pull request enhances the display of execution step messages in both the `ExecutionStepsAccordion` and `ExecutionStepsTable` components by introducing line numbers and improving the formatting of each message line. The changes focus on making log outputs more readable and structured for users.

**Improvements to message rendering:**

* Added line numbers to each log line by introducing a `globalLineNumber` counter in both `executionStepsAccordion.tsx` and `executionStepsTable.tsx`, making it easier to reference specific lines. [[1]](diffhunk://#diff-78d4bc81ace6d6685125e67978c838dfbe5e0c282bd906758ca575f6cb8b1169L370-R414) [[2]](diffhunk://#diff-b098297c7a6fbdad2bfda1ae0447635b04a17229e4f60059e29f4d1878206e2aL425-R468)
* Reformatted each log line to display the line number, timestamp (in `HH:MM:SS` format), and content in a cleaner, more readable layout with improved styling and hover effects. [[1]](diffhunk://#diff-78d4bc81ace6d6685125e67978c838dfbe5e0c282bd906758ca575f6cb8b1169L370-R414) [[2]](diffhunk://#diff-b098297c7a6fbdad2bfda1ae0447635b04a17229e4f60059e29f4d1878206e2aL425-R468)