### PR TITLE
fix: adjust padding for message container in execution steps components

### DIFF
--- a/services/frontend/components/executions/execution/executionStepsAccordion.tsx
+++ b/services/frontend/components/executions/execution/executionStepsAccordion.tsx
@@ -380,7 +380,7 @@ export function ExecutionStepsAccordion({
                                         return (
                                           <div
                                             key={`${dataIndex}-${lineIndex}`}
-                                            className={`container flex items-start gap-3 py-1 hover:bg-default-100/50 transition-colors`}
+                                            className={`container flex items-start gap-3 py-0.3 hover:bg-default-100/50 transition-colors`}
                                           >
                                             <div className="flex-shrink-0 w-8 text-right">
                                               <span className="text-xs text-default-400 font-mono select-none">

--- a/services/frontend/components/executions/execution/executionStepsTable.tsx
+++ b/services/frontend/components/executions/execution/executionStepsTable.tsx
@@ -434,7 +434,7 @@ export function ExecutionStepsTable({
                                   return (
                                     <div
                                       key={`${dataIndex}-${lineIndex}`}
-                                      className={`container flex items-start gap-3 py-1 hover:bg-default-100/50 transition-colors`}
+                                      className={`container flex items-start gap-3 py-0.3 hover:bg-default-100/50 transition-colors`}
                                     >
                                       <div className="flex-shrink-0 w-8 text-right">
                                         <span className="text-xs text-default-400 font-mono select-none">


### PR DESCRIPTION
This pull request makes a minor UI adjustment to the padding of execution step rows in both the accordion and table views. The vertical padding (`py-1`) has been reduced to `py-0.3` for a more compact appearance.

UI adjustments:

* Reduced vertical padding from `py-1` to `py-0.3` for execution step rows in `executionStepsAccordion.tsx` to make the rows more compact.
* Reduced vertical padding from `py-1` to `py-0.3` for execution step rows in `executionStepsTable.tsx` for consistency and a more compact layout.