### PR TITLE
feat: implement StartExecution handler and integrate with flows router

### DIFF
--- a/services/backend/handlers/flows/start_execution.go
+++ b/services/backend/handlers/flows/start_execution.go
@@ -1,4 +1,4 @@
-package executions
+package flows
 
 import (
 	"net/http"
@@ -6,6 +6,7 @@ import (
 
 	"github.com/google/uuid"
 	log "github.com/sirupsen/logrus"
+	"github.com/v1Flows/exFlow/services/backend/functions/auth"
 	"github.com/v1Flows/exFlow/services/backend/functions/encryption"
 	"github.com/v1Flows/exFlow/services/backend/functions/httperror"
 	"github.com/v1Flows/exFlow/services/backend/pkg/models"
@@ -16,23 +17,34 @@ import (
 )
 
 func StartExecution(context *gin.Context, db *bun.DB) {
+	flowID := context.Param("flowID")
+
+	// check if flow with given ID exists
+	var flow models.Flows
+	err := db.NewSelect().Model(&flow).Where("id = ?", flowID).Scan(context)
+	if err != nil {
+		httperror.InternalServerError(context, "Error fetching flow data", err)
+		return
+	}
+
+	// check auth token type
+	tokenType, err := auth.GetTypeFromToken(context.GetHeader("Authorization"))
+	if err != nil {
+		httperror.InternalServerError(context, "Error receiving token type", err)
+		return
+	}
+
+	if tokenType == "project" {
+		tokenType = "Project Token"
+	}
+
 	var execution models.Executions
-	if err := context.ShouldBindJSON(&execution); err != nil {
-		httperror.StatusBadRequest(context, "Error parsing incoming data", err)
-		return
-	}
-
-	// check if flow_id is set
-	if execution.FlowID == "" {
-		httperror.StatusBadRequest(context, "Flow ID is required", nil)
-		return
-	}
-
 	execution.ID = uuid.New()
 	execution.CreatedAt = time.Now()
+	execution.FlowID = flowID
 	execution.Status = "pending"
-	execution.TriggeredBy = "user"
-	_, err := db.NewInsert().Model(&execution).Exec(context)
+	execution.TriggeredBy = tokenType
+	_, err = db.NewInsert().Model(&execution).Exec(context)
 	if err != nil {
 		httperror.InternalServerError(context, "Error creating execution on db", err)
 		return
@@ -59,14 +71,6 @@ func StartExecution(context *gin.Context, db *bun.DB) {
 		Status:    "running",
 		CreatedAt: time.Now(),
 		StartedAt: time.Now(),
-	}
-
-	// get flow data
-	var flow models.Flows
-	err = db.NewSelect().Model(&flow).Where("id = ?", execution.FlowID).Scan(context)
-	if err != nil {
-		httperror.InternalServerError(context, "Error fetching flow data", err)
-		return
 	}
 
 	// check for encryption

--- a/services/backend/router/executions.go
+++ b/services/backend/router/executions.go
@@ -14,9 +14,6 @@ func Executions(router *gin.RouterGroup, db *bun.DB) {
 		execution.GET("/", func(c *gin.Context) {
 			executions.GetExecutions(c, db)
 		})
-		execution.POST("/", func(c *gin.Context) {
-			executions.StartExecution(c, db)
-		})
 
 		execution.GET("/running", func(c *gin.Context) {
 			executions.GetRunningExecutions(c, db)

--- a/services/backend/router/flows.go
+++ b/services/backend/router/flows.go
@@ -35,6 +35,9 @@ func Flows(router *gin.RouterGroup, db *bun.DB) {
 		flow.PUT("/:flowID/maintenance", func(c *gin.Context) {
 			flows.ChangeFlowMaintenance(c, db)
 		})
+		flow.POST("/:flowID/execute", func(c *gin.Context) {
+			flows.StartExecution(c, db)
+		})
 
 		// actions
 		flow.POST("/:flowID/actions", func(c *gin.Context) {

--- a/services/frontend/components/flows/flow/info.tsx
+++ b/services/frontend/components/flows/flow/info.tsx
@@ -1,0 +1,47 @@
+import { Card, CardBody, Snippet, Spacer } from "@heroui/react";
+
+export default function FlowInfo({ flow }: { flow: any }) {
+  return (
+    <div className="flex flex-col gap-4">
+      <Card>
+        <CardBody>
+          <div className="grid lg:grid-cols-2 grid-cols-1 items-center justify-between gap-8">
+            <div>
+              <p className="text-md font-bold">Flow ID</p>
+              <p className="text-sm text-default-500">
+                The unique identifier for this flow
+              </p>
+            </div>
+            <Snippet hideSymbol>{flow.id}</Snippet>
+          </div>
+        </CardBody>
+      </Card>
+
+      <Card>
+        <CardBody>
+          <div className="grid lg:grid-cols-2 grid-cols-1 items-center justify-between gap-8">
+            <div>
+              <p className="text-md font-bold">Remote Execute Flow</p>
+              <p className="text-sm text-default-500">
+                This flow can be executed remotely via the API. You can use the
+                following endpoint to start an execution:
+              </p>
+            </div>
+            <div className="flex flex-col gap-1">
+              <Snippet hideSymbol>
+                {`${process.env.NEXT_PUBLIC_API_URL}/api/v1/flows/${flow.id}/execute`}
+              </Snippet>
+              <p className="text-tiny text-default-500">URL</p>
+              <Spacer />
+              <Snippet hideSymbol>POST</Snippet>
+              <p className="text-tiny text-default-500">Method</p>
+              <Spacer />
+              <Snippet hideSymbol>{`Authorization: <your_api_token>`}</Snippet>
+              <p className="text-tiny text-default-500">Headers</p>
+            </div>
+          </div>
+        </CardBody>
+      </Card>
+    </div>
+  );
+}

--- a/services/frontend/components/flows/flow/tabs.tsx
+++ b/services/frontend/components/flows/flow/tabs.tsx
@@ -9,6 +9,7 @@ import Executions from "@/components/executions/executions";
 import Actions from "./actions";
 import FlowStats from "./stats";
 import FlowSettings from "./settings";
+import FlowInfo from "./info";
 
 export default function FlowTabs({
   projects,
@@ -121,6 +122,17 @@ export default function FlowTabs({
               flow={flow}
               user={user}
             />
+          </Tab>
+          <Tab
+            key="info"
+            title={
+              <div className="flex items-center space-x-2">
+                <Icon icon="hugeicons:information-square" width={20} />
+                <span>Info</span>
+              </div>
+            }
+          >
+            <FlowInfo flow={flow} />
           </Tab>
         </Tabs>
       </div>

--- a/services/frontend/lib/fetch/executions/start.ts
+++ b/services/frontend/lib/fetch/executions/start.ts
@@ -33,16 +33,14 @@ export default async function APIStartExecution(
     }
 
     const res = await fetch(
-      `${process.env.NEXT_PUBLIC_API_URL}/api/v1/executions/`,
+      `${process.env.NEXT_PUBLIC_API_URL}/api/v1/flows/${flowID}/execute/`,
       {
         method: "POST",
         headers: {
           "Content-Type": "application/json",
           Authorization: token.value,
         },
-        body: JSON.stringify({
-          flow_id: flowID,
-        }),
+        body: JSON.stringify({}),
       },
     );
 


### PR DESCRIPTION
This pull request refactors the flow execution API to improve clarity and usability, introduces a new frontend "Info" tab for flows, and updates the execution start endpoint to be more RESTful and easier to use. The changes also enhance authentication handling and provide better API documentation for users.

**Backend API Refactor and Improvements:**

* The start execution handler was moved and renamed from `handlers/executions/start.go` to `handlers/flows/start_execution.go`, and the logic was updated to use a more RESTful endpoint: `POST /api/v1/flows/:flowID/execute`. The handler now fetches the `flowID` from the route, checks if the flow exists, determines the triggering token type for better auditing, and sets the execution's `TriggeredBy` field accordingly. [[1]](diffhunk://#diff-2a52df0a234b1c1647b79ad5acb37b2666bebf30236ec8f9ccd1f2a16a34234aL1-R9) [[2]](diffhunk://#diff-2a52df0a234b1c1647b79ad5acb37b2666bebf30236ec8f9ccd1f2a16a34234aL19-R47)
* The old execution start route (`POST /api/v1/executions/`) was removed from the router, and the new route (`POST /api/v1/flows/:flowID/execute`) was added under the flows router for better API organization and discoverability. [[1]](diffhunk://#diff-6b40fa77e7f0113bd0d56007d220c79428564e205e66818bf6ccc0211365a4dfL17-L19) [[2]](diffhunk://#diff-46df36880b1aa0762ee4e1a320922bbc4ae8c4dd99220fb9815d1a689b659707R38-R40)

**Frontend Enhancements:**

* A new `FlowInfo` component was added, providing users with detailed information about the flow, including its unique ID and clear instructions for triggering executions remotely via the updated API endpoint.
* The "Info" tab was integrated into the flow details UI, making the new documentation and endpoint details easily accessible to users. [[1]](diffhunk://#diff-b7151e6db8a30c1c0dbdc25367cb503d8b0599f50f92446099f3440f10f99655R12) [[2]](diffhunk://#diff-b7151e6db8a30c1c0dbdc25367cb503d8b0599f50f92446099f3440f10f99655R126-R136)

**Client API Usage Update:**

* The frontend's `APIStartExecution` function was updated to use the new endpoint (`/api/v1/flows/:flowID/execute/`) and no longer sends the `flow_id` in the request body, aligning with the backend changes.