### PR TITLE
chore: update version to 1.5.2 in backend and frontend configurations

### DIFF
--- a/release-notes.md
+++ b/release-notes.md
@@ -1,18 +1,16 @@
 # Release Notes
 
-## [Version 1.5.1] - 2025-08-08
+## [Version 1.5.2] - 2025-08-15
 
 ### Added
 - none
 
 ### Changed
-- Background of search
-- Avatar radius
-- Autoscroll for execution table view
-- Action password params are now blurred instead of showing the encrypted string
+- none
 
 ### Fixed
-- Flow action params are not decrypted when the /flows api endpoint is queried
+- Step Action encryption
+- Execution auto-scroll
 
 ### Known Issues
 - No known issues at this time.

--- a/services/backend/main.go
+++ b/services/backend/main.go
@@ -12,7 +12,7 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-const version string = "1.5.1"
+const version string = "1.5.2"
 
 var (
 	configFile = kingpin.Flag("config", "Config file").Short('c').Default("config.yaml").String()

--- a/services/frontend/config/site.ts
+++ b/services/frontend/config/site.ts
@@ -3,7 +3,7 @@ export type SiteConfig = typeof siteConfig;
 export const siteConfig = {
   name: "exFlow",
   description: "exFlow is an workflow automation tool",
-  version: "1.5.1",
+  version: "1.5.2",
   navItems: [
     {
       label: "Dashboard",


### PR DESCRIPTION
This pull request updates the application version to 1.5.2 in both the backend and frontend codebases to ensure consistency across the project.

Version updates:

* Updated the `version` constant in `services/backend/main.go` from "1.5.1" to "1.5.2" to reflect the new release version.
* Updated the `version` property in the `siteConfig` object in `services/frontend/config/site.ts` from "1.5.1" to "1.5.2".